### PR TITLE
Final Fixes

### DIFF
--- a/Assets/Scripts/Players/CastSpell.cs
+++ b/Assets/Scripts/Players/CastSpell.cs
@@ -447,6 +447,7 @@ public class CastSpell : MonoBehaviour
                     switch (PlayerOneState)
                     {
                         case 1:
+                            spellTarget.transform.rotation = Quaternion.identity;
                             break;
                         case 3:
                             spellTarget.transform.eulerAngles = new Vector3(0, 180, 0);

--- a/Assets/Scripts/Players/PlayerOneMovement.cs
+++ b/Assets/Scripts/Players/PlayerOneMovement.cs
@@ -394,6 +394,15 @@ public class PlayerOneMovement : MonoBehaviour {
             {
                 unPetrify = false;
             }
+           
+            if(unPetrify == true)
+            {
+                animator.enabled = true;
+            }
+            else if(unPetrify == false)
+            {
+                animator.enabled = false;
+            }
 
             //Slow flicker fix
             SlowTimeInitial += Time.deltaTime;

--- a/Assets/Scripts/Spells/Lightning.cs
+++ b/Assets/Scripts/Spells/Lightning.cs
@@ -111,7 +111,7 @@ public class Lightning : MonoBehaviour
             Destroy(ps);
         }
         
-        yield return new WaitForSeconds(stunDuration + 1f);
+        yield return new WaitForSeconds(stunDuration + 2f);
         if (anim != null)
         {
             anim.SetBool("Stunned", false);

--- a/Assets/Scripts/Spells/Petrify.cs
+++ b/Assets/Scripts/Spells/Petrify.cs
@@ -83,8 +83,8 @@ public class Petrify : MonoBehaviour {
             }
             Destroy(this.gameObject, 8);
             child = player.GetComponentsInChildren<Renderer>();
-            spellBase.Stun(player, stunDuration, turnStone);
             StartCoroutine(CheckPetrifyStatus());
+            spellBase.Stun(player, stunDuration, turnStone);
             StartCoroutine(Wait(this.gameObject));
         }
         if (hit == false && other.tag == "Boundary" && once == false)

--- a/Assets/Scripts/Spells/SpellBase.cs
+++ b/Assets/Scripts/Spells/SpellBase.cs
@@ -121,7 +121,7 @@ public class SpellBase : MonoBehaviour {
 
         float stunTime = 0;
 
-        while (stunTime < stunDuration)
+        while (stunTime <= stunDuration)
         {
             player.gameObject.GetComponent<PlayerOneMovement>().SetMove(false);
             stunTime += Time.deltaTime;
@@ -132,6 +132,7 @@ public class SpellBase : MonoBehaviour {
                     if (r.name == "Body" || r.name == "Hat" || r.name == "HatEyes" || r.name == "Poncho") r.material = mat;
                 }
             }
+
             yield return null;
         }
         //  yield return new WaitForSeconds(stunDuration);
@@ -171,7 +172,7 @@ public class SpellBase : MonoBehaviour {
         float slowTimePassed = 0;
         bool noSlow = false;
 
-        while (slowTimePassed < slowDuration)
+        while (slowTimePassed <= slowDuration)
         {
             slowTimePassed += Time.deltaTime;
 

--- a/Assets/Scripts/Spells/SpellBase.cs
+++ b/Assets/Scripts/Spells/SpellBase.cs
@@ -121,7 +121,7 @@ public class SpellBase : MonoBehaviour {
 
         float stunTime = 0;
 
-        while (stunTime <= stunDuration)
+        while (stunTime < stunDuration)
         {
             player.gameObject.GetComponent<PlayerOneMovement>().SetMove(false);
             stunTime += Time.deltaTime;
@@ -171,7 +171,7 @@ public class SpellBase : MonoBehaviour {
         float slowTimePassed = 0;
         bool noSlow = false;
 
-        while (slowTimePassed <= slowDuration)
+        while (slowTimePassed < slowDuration)
         {
             slowTimePassed += Time.deltaTime;
 

--- a/Assets/Scripts/Traps/LogProjectile.cs
+++ b/Assets/Scripts/Traps/LogProjectile.cs
@@ -72,13 +72,13 @@ public class LogProjectile : MonoBehaviour {
             switch (playerOne.GetState())
             {
                 case 1:
-                    if (rb.velocity.x > speedForKnockback)
+                    if (rb.velocity.x > speedForKnockback && canHit == true)
                     {
                         box.center = new Vector3(0.0065f, 0, -0.0003f);
                         box.enabled = true;
                     }
                     //left
-                    else if (rb.velocity.x < -speedForKnockback)
+                    else if (rb.velocity.x < -speedForKnockback && canHit == true)
                     {
                         box.center = new Vector3(-0.0065f, 0, -0.0003f);
                         box.enabled = true;
@@ -89,13 +89,13 @@ public class LogProjectile : MonoBehaviour {
                     }
                     break;
                 case 2:
-                    if (rb.velocity.z > speedForKnockback)
+                    if (rb.velocity.z > speedForKnockback && canHit == true)
                     {
                         box.center = new Vector3(0.0065f, 0, -0.0003f);
                         box.enabled = true;
                     }
                     //left
-                    else if (rb.velocity.z < -speedForKnockback)
+                    else if (rb.velocity.z < -speedForKnockback && canHit == true)
                     {
                         box.center = new Vector3(-0.0065f, 0, -0.0003f);
                         box.enabled = true;
@@ -107,12 +107,12 @@ public class LogProjectile : MonoBehaviour {
                     break;
                 case 3:
                     //left
-                    if (rb.velocity.x > speedForKnockback)
+                    if (rb.velocity.x > speedForKnockback && canHit == true)
                     {
                         box.center = new Vector3(-0.0065f, 0, -0.0003f);
                         box.enabled = true;
                     }
-                    else if (rb.velocity.x < -speedForKnockback)
+                    else if (rb.velocity.x < -speedForKnockback && canHit == true)
                     {
                         box.center = new Vector3(0.0065f, 0, -0.0003f);
                         box.enabled = true;
@@ -124,12 +124,12 @@ public class LogProjectile : MonoBehaviour {
                     break;
                 case 4:
                     //left
-                    if (rb.velocity.z > speedForKnockback)
+                    if (rb.velocity.z > speedForKnockback && canHit == true)
                     {
                         box.center = new Vector3(-0.0065f, 0, -0.0003f);
                         box.enabled = true;
                     }
-                    else if (rb.velocity.z < 0)
+                    else if (rb.velocity.z < -speedForKnockback && canHit == true)
                     {
                         box.center = new Vector3(0.0065f, 0, -0.0003f);
                         box.enabled = true;
@@ -194,7 +194,7 @@ public class LogProjectile : MonoBehaviour {
         yield return new WaitForSeconds(lifeTime);
         canHit = false;
         box.enabled = false;
-        yield return new WaitForSeconds(2f);
+        yield return new WaitForSeconds(stunDuration + 2f);
         Destroy(this.transform.parent.gameObject);
     }
     

--- a/Assets/Scripts/Traps/LogProjectile.cs
+++ b/Assets/Scripts/Traps/LogProjectile.cs
@@ -148,12 +148,12 @@ public class LogProjectile : MonoBehaviour {
         {
             if (hit)
             {
-                if (hit && knockTimer < 7 && knockTimer >= 5)
+                if (knockTimer < 7 && knockTimer >= 5)
                 {
                     trapBase.KnockBack(player, knockBackValue, 0);
                     knockTimer++;
                 }
-                else if (hit && knockTimer < 7)
+                else if (knockTimer < 7)
                 {
                     trapBase.KnockBack(player, 0, knockUpValue);
                     trapBase.Stun(player.gameObject, stunDuration);
@@ -175,6 +175,7 @@ public class LogProjectile : MonoBehaviour {
         {
             player = col.gameObject;
             hit = true;
+            trapBase.UpdatePlayerVelocities(col.gameObject);
             anim = player.GetComponent<PlayerOneMovement>().GetAnim();
             if (logHitSFX != null && !sfxPlayed)
             {

--- a/Assets/Scripts/Traps/TrapBase.cs
+++ b/Assets/Scripts/Traps/TrapBase.cs
@@ -140,9 +140,9 @@ public class TrapBase : MonoBehaviour {
         float stunTimePassed = 0;
         while (stunTimePassed <= stunDuration)
         {
-            stunTimePassed += Time.deltaTime;
-
             obj.gameObject.GetComponent<PlayerOneMovement>().SetMove(false);
+
+            stunTimePassed += Time.deltaTime;
 
             yield return null;
         }

--- a/Assets/Scripts/Traps/TrapBase.cs
+++ b/Assets/Scripts/Traps/TrapBase.cs
@@ -138,7 +138,7 @@ public class TrapBase : MonoBehaviour {
         obj.gameObject.GetComponent<Rigidbody>().velocity = new Vector3(0, obj.gameObject.GetComponent<Rigidbody>().velocity.y, 0);
 
         float stunTimePassed = 0;
-        while (stunTimePassed < stunDuration)
+        while (stunTimePassed <= stunDuration)
         {
             obj.gameObject.GetComponent<PlayerOneMovement>().SetMove(false);
 

--- a/Assets/Scripts/Traps/TrapBase.cs
+++ b/Assets/Scripts/Traps/TrapBase.cs
@@ -149,6 +149,8 @@ public class TrapBase : MonoBehaviour {
 
         obj.gameObject.GetComponent<PlayerOneMovement>().SetMove(true);
 
+        once = false;
+
         if (trap != null)
         {
             Destroy(trap);

--- a/Assets/Scripts/Traps/TrapBase.cs
+++ b/Assets/Scripts/Traps/TrapBase.cs
@@ -138,7 +138,7 @@ public class TrapBase : MonoBehaviour {
         obj.gameObject.GetComponent<Rigidbody>().velocity = new Vector3(0, obj.gameObject.GetComponent<Rigidbody>().velocity.y, 0);
 
         float stunTimePassed = 0;
-        while (stunTimePassed <= stunDuration)
+        while (stunTimePassed < stunDuration)
         {
             obj.gameObject.GetComponent<PlayerOneMovement>().SetMove(false);
 


### PR DESCRIPTION
Log projectile on the fourth face has its collision to right work with minimum required speed. Forgot to change the 0 to the min speed. Log Projectile also didn't update player velocities when hitting the player like the spikes did. It does now for better knockback.

Log projectile would turn off collider for 2 seconds before dying but forgot to put the bool for that into the other parts so the collider would get overwritten and could still be on right before it died probably causing the infinite stun.

Instant spell cursor rotates properly when going from face 4 to face 1.

Animator disabling and enabling should be more consistent when hit with multiple petrifies.

Stun works properly for logs and spikes now. Previously only the first instance of stun worked.